### PR TITLE
Adiciona peso ao cálculo da complexidade financeira do projeto

### DIFF
--- a/salic_ml_web/indicators/fetch_complexity.py
+++ b/salic_ml_web/indicators/fetch_complexity.py
@@ -1,15 +1,16 @@
 from .views import projects_to_analyse, register_project_indicator
 from .models import Entity, Metric, Indicator
 from .financial_metrics_instance import financial_metrics
+from .utils import indicators_average
 
 
 def get_financial_complexity(metrics):
     try:
-        complexity = 100 - (metrics['easiness']['easiness'] * 100)
+        value = indicators_average.fetch_weighted_complexity(metrics)
     except:
-        complexity = 1
+        value = 1
 
-    return complexity
+    return value
 
 
 def pre_fetch_financial_complexity():
@@ -33,19 +34,6 @@ def pre_fetch_financial_complexity():
              "project_name": "Circulação de oficinas e shows - Claudia Cimbleris", "analist": "Modelo"},
         ]
 
-    metrics_list = [
-        'items',
-        'raised_funds',
-        'verified_funds',
-        'approved_funds',
-        'common_items_ratio',
-        'total_receipts',
-        'new_providers',
-        'proponent_projects',
-        'easiness',
-        'items_prices'
-    ]
-
     for project in projects:
         try:
             entity = Entity.objects.get(pronac=int(project['pronac']))
@@ -54,6 +42,6 @@ def pre_fetch_financial_complexity():
                 project['pronac']), name=project['project_name'])
 
         metrics = financial_metrics.get_metrics(project['pronac'])
-        print(get_financial_complexity(metrics))
+        print("Complexity value:", get_financial_complexity(metrics))
         financial_complexity_indicator = register_project_indicator(int(
             project['pronac']), 'complexidade_financeira', get_financial_complexity(metrics))

--- a/salic_ml_web/indicators/indicators_requests.py
+++ b/salic_ml_web/indicators/indicators_requests.py
@@ -1,6 +1,7 @@
 import requests
+import os
 
-BASE_URL = "https://lappislearning.lappis.rocks"
+BASE_URL = os.environ.get('LAPPIS_LEARNING_URL', 'https://lappislearning.lappis.rocks')
 
 
 class HttpFinancialMetrics:

--- a/salic_ml_web/indicators/utils/indicators_average.py
+++ b/salic_ml_web/indicators/utils/indicators_average.py
@@ -1,0 +1,24 @@
+def fetch_weighted_complexity(metrics):
+    metrics_weights = {
+        'items': 1,
+        'to_approve_funds': 5,
+        'proponent_projects': 2,
+        'new_provders': 1,
+        'verified_approved': 2
+    }
+
+    max_total = sum([metrics_weights[metric_name] for metric_name in metrics_weights])
+
+    total = 0
+
+    for metric_name in metrics_weights:
+        try:
+            if metrics[metric_name] is not None:
+                if metrics[metric_name]['is_outlier']:
+                    total += metrics_weights[metric_name]
+        except KeyError:
+            pass
+
+    value = total/max_total
+
+    return 1 - value

--- a/salic_ml_web/indicators/utils/indicators_average.py
+++ b/salic_ml_web/indicators/utils/indicators_average.py
@@ -4,7 +4,13 @@ def fetch_weighted_complexity(metrics):
         'to_approve_funds': 5,
         'proponent_projects': 2,
         'new_provders': 1,
-        'verified_approved': 2
+        'verified_approved': 2,
+        'raised_funds': 0,
+        'verified_funds': 0,
+        'approved_funds': 0,
+        'common_items_ratio': 0,
+        'total_receipts': 0,
+        'items_prices': 0
     }
 
     max_total = sum([metrics_weights[metric_name] for metric_name in metrics_weights])

--- a/salic_ml_web/indicators/utils/string_formatter.py
+++ b/salic_ml_web/indicators/utils/string_formatter.py
@@ -4,7 +4,8 @@ def list_to_string_tuple(elements_list):
     for each in elements_list:
         final_string += "'" + str(each) + "', "
 
-    final_string = final_string[:-2]
+    if len(elements_list) != 0:
+        final_string = final_string[:-2]
 
     final_string += ')'
 


### PR DESCRIPTION
Antes, não havia o cálculo dos pesos das métricas para gerar uma complexidade ponderada.